### PR TITLE
1.0.0-Alfa-3.1 - bugfix patch

### DIFF
--- a/Data/JSON/items/consumables.json
+++ b/Data/JSON/items/consumables.json
@@ -1,28 +1,28 @@
 {
     "common": {
-        "mushroom": "1",
-        "bread": "2",
-        "potato": "3"
+        "mushroom": 1,
+        "bread": 2,
+        "potato": 3
     },
     "uncommon": {
-        "apple": "4",
-        "pear": "5"
+        "apple": 4,
+        "pear": 5
     },
     "rare": {
-        "beef steak": "6",
-        "banana": "7"
+        "beef steak": 6,
+        "banana": 7
     },
     "super rare": {
-        "cheese": "8",
-        "chicken soup": "9"
+        "cheese": 8,
+        "chicken soup": 9
     },
     "epic": {
-        "cake": "10",
-        "chocolate": "11",
-        "whole cheese wheel": "11"
+        "cake": 10,
+        "chocolate": 11,
+        "whole cheese wheel": 11
     },
     "legendary": {
-        "pizza": "12",
-        "melon": "13"
+        "pizza": 12,
+        "melon": 13
     }
 }

--- a/Documetation/overview.md
+++ b/Documetation/overview.md
@@ -4,11 +4,12 @@
 
 ### Changes
 
-   Version    |      Description                                  |     Date    |                   Patch notes                   |
---------------|---------------------------------------------------|-------------|-------------------------------------------------|
- 1.0.0-Alfa-1 | Project Alfa Release                              | 24. 9. 2023 | [1.0.0-Alfa-1.md](./patchNotes/1.0.0-Alfa-1.md) |
- 1.0.0-Alfa-2 | Bugfixes, added Magic                             | 25. 9. 2023 | [1.0.0-Alfa-2.md](./patchNotes/1.0.0-Alfa-2.md) |
- 1.0.0-Alfa-3 | Magic fix, Items, Backpack & project structure    |  1. 3. 2024 | [1.0.0-Alfa-3.md](./patchNotes/1.0.0-Alfa-3.md) |
+   Version      |      Description                                  |     Date    |                   Patch notes                       |
+----------------|---------------------------------------------------|-------------|-----------------------------------------------------|
+ 1.0.0-Alfa-1   | Project Alfa Release                              | 24. 9. 2023 | [1.0.0-Alfa-1.md](./patchNotes/1.0.0-Alfa-1.md)     |
+ 1.0.0-Alfa-2   | Bugfixes, added Magic                             | 25. 9. 2023 | [1.0.0-Alfa-2.md](./patchNotes/1.0.0-Alfa-2.md)     |
+ 1.0.0-Alfa-3   | Magic fix, Items, Backpack & project structure    |  1. 3. 2024 | [1.0.0-Alfa-3.md](./patchNotes/1.0.0-Alfa-3.md)     |
+ 1.0.0-Alfa-3.1 | Fixed game breaking bug, added info on PR 4 & 5   | 26. 4. 2024 | [1.0.0-Alfa-3.1.md](./patchNotes/1.0.0-Alfa-3.1.md) |
 
 ## Playing
 

--- a/Documetation/patchNotes/1.0.0-Alfa-3.1.md
+++ b/Documetation/patchNotes/1.0.0-Alfa-3.1.md
@@ -1,0 +1,5 @@
+# 1.0.0-Alfa-3.1.md - PR:[6](https://github.com/Sklenik/TextRPG/pull/6)
+Date : 26. 4. 2024
+ - fixed a bug that caused the game to crash when an item was eaten (consumable healvalues were defined as strings that on assignment overwritten the default integers in the item class, causing item.healvalue to return strings which crashed when a message that expected integer got the string instead)
+ - PR 4 was used to remove resolved TODOs
+ - PR 5 was used to update overview.md (missing version)

--- a/Library/handlers/itemHandler.py
+++ b/Library/handlers/itemHandler.py
@@ -53,8 +53,8 @@ def handleEatLoop(player, enemy, dialog=True, itemToEat=entities.nullItem()) -> 
     action = utils.yesNoActionHandler(doYouWantToEatMessage%itemToEat.name)
     
     if action == 1:
-        if int(itemToEat.healValue) != 0:
-            player.hp += int(itemToEat.healValue)
+        if itemToEat.healValue != 0:
+            player.hp += itemToEat.healValue
         player.backpack.substractItem(itemToEat)
         print(youAteMessage%(itemToEat.noQtyName(),itemToEat.healValue))
 


### PR DESCRIPTION
- fixed a bug that caused the game to crash when an item was eaten (consumable healvalues were defined as strings that on assignment overwritten the default integers in the item class, causing item.healvalue to return strings which crashed when a message that expected integer got the string instead)